### PR TITLE
Fix regex check for valid RSA key

### DIFF
--- a/lib/transip.rb
+++ b/lib/transip.rb
@@ -283,7 +283,7 @@ class Transip
 
     }
     input.merge!(options)
-    raise "Invalid RSA key" unless @key =~ /-----BEGIN RSA PRIVATE KEY-----(.*)-----END RSA PRIVATE KEY-----/sim
+    raise "Invalid RSA key" unless @key =~ /-----BEGIN( RSA)? PRIVATE KEY-----(.*)-----END( RSA)? PRIVATE KEY-----/sim
     serialized_input = serialize_parameters(input)
 
     digest = Digest::SHA512.new.digest(serialized_input)


### PR DESCRIPTION
Generating a key pair at https://www.transip.nl/cp/mijn-account/#api
yields a private key with a `BEGIN RSA PRIVATE KEY` header, as opposed to
the `BEGIN PRIVATE KEY` header the regex checks for.

Since there are probably still valid keys in use that include the `RSA`
part in the header, I made it optional (as opposed to removing it
entirely).

It might be a good idea to consider not doing the check in the first place.
