### PR TITLE
Allow wildcard DnsEntry

### DIFF
--- a/lib/transip/client.rb
+++ b/lib/transip/client.rb
@@ -86,6 +86,7 @@ module Transip
       output = URI.encode_www_form_component(input)
       output.gsub!('+', '%20')
       output.gsub!('%7E', '~')
+      output.gsub!('*', '%2A')
       output
     end
 


### PR DESCRIPTION
Simple fix

We use the API to provision domains at `*.stage.inventid.us`, however your implementation did not allow that. It turned out it did not adequately urlencode the `*` symbol. In return TransIP therefore denied the request.

This simple one-liner fixes it, although it cost me quite a bit of time.

In order to allow for easy merging I have not cleaned up any old code and gone for the easy solution.
